### PR TITLE
Add workflow for issue due date reminders

### DIFF
--- a/.github/workflows/issue-due-date-reminder.yml
+++ b/.github/workflows/issue-due-date-reminder.yml
@@ -1,0 +1,62 @@
+name: Issue due date reminders
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remind on upcoming due dates
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const today = new Date();
+            today.setUTCHours(0, 0, 0, 0);
+
+            const dueDateRegex = /due\s*date\s*[:：]\s*(\d{4}-\d{2}-\d{2})/i;
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              { owner, repo, state: "open", per_page: 100 }
+            );
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              const match = issue.body?.match(dueDateRegex);
+              if (!match) continue;
+
+              const dueDate = new Date(`${match[1]}T00:00:00Z`);
+              const diffDays = Math.round((dueDate - today) / (1000 * 60 * 60 * 24));
+              if (![3, 1].includes(diffDays)) continue;
+
+              const reminderTag = `Due date reminder (${match[1]})`;
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: issue.number, per_page: 100 }
+              );
+              const alreadyReminded = comments.some((comment) =>
+                comment.body?.includes(reminderTag)
+              );
+              if (alreadyReminded) continue;
+
+              const dayLabel = diffDays === 3 ? "3 days" : "1 day";
+              const body = [
+                `🔔 ${reminderTag}`,
+                ``,
+                `This issue is due in ${dayLabel} on **${match[1]}**.`,
+                `Please update the due date or status if needed.`,
+              ].join("\n");
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
### Motivation
- Provide automated reminders for issues that have a `Due date: YYYY-MM-DD` specified so owners are notified before deadlines. 
- Send reminders specifically when a due date is 3 days or 1 day away to prompt updates or status changes. 
- Avoid duplicate reminders by checking existing issue comments before posting a new notification.

### Description
- Add a new GitHub Actions workflow at `/.github/workflows/issue-due-date-reminder.yml` triggered daily at `0 9 * * *` and via `workflow_dispatch`.
- Use `actions/github-script@v7` to list open issues, skip PRs, and parse issue bodies with the regex `due\s*date\s*[:：]\s*(\d{4}-\d{2}-\d{2})` to extract `YYYY-MM-DD` dates.
- Calculate the UTC day difference and only act when the date is `3` or `1` days away, then post a comment using `github.rest.issues.createComment` with a `Due date reminder (YYYY-MM-DD)` tag.
- Prevent duplicate reminders by paginating issue comments and checking for an existing comment that includes the reminder tag.

### Testing
- No automated tests were run because this is a workflow-only change; the workflow will execute on schedule or when manually dispatched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b7d09e864832f9eb1e688a44e790a)